### PR TITLE
Get rid of unnecessary @schematics/angular package instalation

### DIFF
--- a/commands/application.angular.js
+++ b/commands/application.angular.js
@@ -17,7 +17,6 @@ function runSchematicCommand(schematicCommand, options, evaluatingOptions) {
 
     const commandArguments = [
         '-p', '@angular-devkit/schematics-cli@latest',
-        '-p', '@schematics/angular@latest',
         '-p', collectionPath,
         '-c', `"schematics ${collectionName}:${schematicCommand}${additionalOptions.join('')} --dry-run=false"`
     ];


### PR DESCRIPTION
It will be installed as a devextreme-schematics [dependency](https://github.com/DevExpress/devextreme-schematics/blob/master/package.json#L17).