### PR TITLE
Use the latest version of `less` package

### DIFF
--- a/commands/themebuider.js
+++ b/commands/themebuider.js
@@ -95,8 +95,9 @@ const runThemeBuilder = (rawOptions) => {
         options.sassCompiler = scssCompiler;
         options.lessCompiler = require('less/lib/less-node');
 
+        options.lessCompiler.options = options.lessCompiler.options || {};
+        options.lessCompiler.options['math'] = 'always';
         if(options.assetsBasePath) {
-            options.lessCompiler.options = options.lessCompiler.options || {};
             options.lessCompiler.options['rootpath'] = options.assetsBasePath;
         }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "devextreme-themebuilder": "^18.2.3",
-    "less": "^2.6.1",
+    "less": "^3.8.1",
     "minimist": "^1.2.0",
     "node-sass": "^4.9.3",
     "semver": "^5.6.0"


### PR DESCRIPTION
We need the `math` flag here as well because the default value may be changed in the future versions of `less` package.