### PR TITLE
Fix tests blinking (#157)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,11 @@ jobs:
       - run:
           name: Run test
           command: npm run test
+          no_output_timeout: 15m
       - store_artifacts:
           path: test-results.xml
           prefix: tests
       - store_artifacts:
           path: ./packages/devextreme-cli/testing/__tests__/__diff_snapshots__
+      - store_artifacts:
+          path: ./packages/devextreme-cli/testing/sandbox/logs

--- a/packages/devextreme-cli/testing/app-template.test.shared.js
+++ b/packages/devextreme-cli/testing/app-template.test.shared.js
@@ -61,6 +61,9 @@ module.exports = (env) => {
                                     timeout: 0,
                                     waitUntil: 'networkidle0'
                                 });
+                                await page.waitFor('.full-height-scrollable, .with-footer', {
+                                    timeout: 0
+                                });
 
                                 return page;
                             }


### PR DESCRIPTION
* Store logs

* Wait for page content before when opening new page