### PR TITLE
Add package name for react app creation

### DIFF
--- a/packages/devextreme-cli/src/applications/application.react.js
+++ b/packages/devextreme-cli/src/applications/application.react.js
@@ -42,7 +42,7 @@ const updateJsonPropName = (path, name) => {
 };
 
 const create = (appName, options) => {
-    const commandArguments = ['create-react-app', appName];
+    const commandArguments = ['-p=create-react-app', 'create-react-app', appName];
 
     getLayoutInfo(options.layout).then((layoutInfo) => {
         runCommand('npx', commandArguments).then(() => {


### PR DESCRIPTION
npx reads `package` from config (command-line-arguments, env).
If you run ` npx -p devextreme-cli devextreme new react-app app-name3` the env variable `npm_config_package` is set to 'devextreme-cli'. And when we start `npx create-react-app app-name3` with spawn it fails with `'create-react-app' is not recognized as an internal or external command, operable program or batch file.`.
So we should to set a package name in this npx command to rewrite `package`.