### PR TITLE
Get app bootstrap string using a regex

### DIFF
--- a/packages/devextreme-cli/src/applications/application.angular.js
+++ b/packages/devextreme-cli/src/applications/application.angular.js
@@ -128,7 +128,8 @@ const changeMainTs = (appPath) => {
     moduleWorker.insertImport(filePath, 'devextreme/ui/themes', 'themes', true);
 
     const fileContent = fs.readFileSync(filePath).toString();
-    const firstChaptStr = 'platformBrowserDynamic().bootstrapModule(AppModule)';
+    const bootstrapPattern = /platformBrowserDynamic\(\)\.bootstrapModule\(\s*AppModule\s*(?:,\s*\{[^}]*\})?\s*\)/;
+    const firstChaptStr = fileContent.match(bootstrapPattern)[0];
     const lastChaptStr = '.catch(err => console.error(err));';
 
     fs.writeFileSync(


### PR DESCRIPTION
In Angular 18, an argument was added when calling the bootstrap module. 
ng 17
```
platformBrowserDynamic().bootstrapModule(AppModule)
.catch(err => console.error(err));
```


ng 18

```platformBrowserDynamic().bootstrapModule(AppModule, {
  ngZoneEventCoalescing: true
})
.catch(err => console.error(err));
```


Our CLI was designed only for a specific case without the argument. As a result, the text was patched incorrectly, and the application broke.