### PR TITLE
fix: use --ignore-scripts for the typescript installation

### DIFF
--- a/packages/devextreme-schematics/src/migrate-config-components/template-migrator.ts
+++ b/packages/devextreme-schematics/src/migrate-config-components/template-migrator.ts
@@ -89,9 +89,9 @@ export async function applyInlineComponentTemplateMigrations(
         '  3. Temporary installation (npm cache)\n\n' +
         'To resolve this issue, install TypeScript manually.\n\n' +
         'Project installation:\n' +
-        '  npm install typescript --save-dev\n\n' +
+        '  npm install typescript --save-dev --ignore-scripts\n\n' +
         'Global installation:\n' +
-        '  npm install -g typescript\n\n'
+        '  npm install -g typescript --ignore-scripts\n\n'
       );
       return;
   }

--- a/packages/devextreme-schematics/src/utility/typescript-resolver.ts
+++ b/packages/devextreme-schematics/src/utility/typescript-resolver.ts
@@ -115,7 +115,7 @@ function tryResolveViaTemporaryInstall(): any {
       JSON.stringify(packageJson, null, 2)
     );
 
-    execSync('npm install --silent --no-progress', {
+    execSync('npm install --silent --no-progress --ignore-scripts', {
       cwd: tmpDir,
       stdio: 'ignore',
       timeout: 30000


### PR DESCRIPTION

### Details
The `typescript` package has no dependencies and own lifecycle scripts, so I assume it's safe to install it with `--ignore-scripts`