### PR TITLE
fix: update checkout to v5, exclude EJS templates from CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,13 +36,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        config: |
+          paths-ignore:
+            - packages/devextreme-cli/src/templates
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
Fixes two remaining CodeQL warnings:

1. **Node.js 20 deprecation**: `actions/checkout@v4` → `@v5` (Node.js 20 will be removed Sept 16, 2026)
2. **1456 parse errors**: EJS template files in `packages/devextreme-cli/src/templates/` contain `<%=...%>` syntax inside `.ts`/`.tsx` files, which CodeQL's JavaScript extractor can't parse. These are excluded via `paths-ignore`.