### PR TITLE
fix: exclude EJS templates from CodeQL extractor

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,6 +46,9 @@ jobs:
         config: |
           paths-ignore:
             - packages/devextreme-cli/src/templates
+      env:
+        LGTM_INDEX_FILTERS: |
+          exclude:packages/devextreme-cli/src/templates
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
The `paths-ignore` config only filters analysis results but the JavaScript extractor still tries to parse all `.ts`/`.tsx` files, producing 17 parse error warnings for EJS templates.

Adding `LGTM_INDEX_FILTERS` environment variable tells the extractor to completely skip the template files during database creation, eliminating the warnings at the source.