### PR TITLE
chore: add workflow_dispatch to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 6'
 


### PR DESCRIPTION
Add `workflow_dispatch` trigger to the CodeQL workflow to allow manual runs from GitHub Actions UI.