### PR TITLE
fix: exclude schematics templates from CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,6 +47,7 @@ jobs:
         config: |
           paths-ignore:
             - packages/devextreme-cli/src/templates
+            - packages/devextreme-schematics/src/*/files
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
Exclude additional template directories from CodeQL analysis to fix remaining 17 parse error warnings:

- `packages/devextreme-schematics/src/*/files` — Angular schematics templates containing EJS syntax (`<%= ... %>`)
- `templates-generator` — template generator config files with EJS syntax

These files are not runtime code and cause false "Type parameter declaration expected" parse errors in CodeQL.